### PR TITLE
fix link marker position if data source is ygopro

### DIFF
--- a/source/cardData.js
+++ b/source/cardData.js
@@ -302,36 +302,33 @@ export default class CardData {
   }
 
   get _link_() {
+    if (this.type2 !== 'lj') {
+      this.link_num = 0;
+      return [false, false, false, false, false, false, false, false];
+    }
+
+    let link = [];
     if (this.dbData.link instanceof Array && this.dbData.link.length >= 8) {
-      this.link_num = this.dbData.link.reduce((num, item) => {
+      link = this.dbData.link.slice(0, 8);
+    } else {
+      const LINK_DIRECTION_SOUTHWEST = 0x1, LINK_DIRECTION_SOUTH = 0x2, LINK_DIRECTION_SOUTHEAST = 0x4,
+        LINK_DIRECTION_WEST = 0x8, LINK_DIRECTION_EAST = 0x20, LINK_DIRECTION_NORTHWEST = 0x40, LINK_DIRECTION_NORTH = 0x80,
+        LINK_DIRECTION_NORTHEAST = 0x100;
+      const MARKER_POSITIONS = [LINK_DIRECTION_NORTHWEST, LINK_DIRECTION_NORTH, LINK_DIRECTION_NORTHEAST, LINK_DIRECTION_WEST,
+        LINK_DIRECTION_EAST, LINK_DIRECTION_SOUTHWEST, LINK_DIRECTION_SOUTH, LINK_DIRECTION_SOUTHEAST];
+
+      const linkInt = this.defend;
+      for(const i in MARKER_POSITIONS) {
+          link.push((linkInt & MARKER_POSITIONS[i]) === MARKER_POSITIONS[i]);
+      }
+
+      this.link_num = link.reduce((num, item) => {
         num += item ? 1 : 0;
         return num;
       }, 0);
 
-      return this.dbData.link;
+      return link;
     }
-
-    if (this.type2 !== "lj") {
-      this.link_num = 0;
-      return [false, false, false, false, false, false, false, false, false];
-    }
-
-    let link = this.defend;
-    let link_ = link.toString(2);
-    if (link_.length > 9) {
-      link_ = link_.substr(-9);
-    }
-    let num = 0;
-    let res = [false, false, false, false, false, false, false, false, false];
-    for (let i = 0; i < link_.length; i++) {
-      let s = link_.substr(i, 1);
-      if (parseInt(s)) {
-        res[i + 9 - link_.length] = true;
-        num++;
-      }
-    }
-    this.link_num = num;
-    return res;
   }
 
   get defaultColor() {


### PR DESCRIPTION
ygopro里的linkMarker位置(def属性的各bit)是这样的: the positions of link marker(every bit in def attr) in ygopro are:
```
0x40 0x80 0x100
0x8  0x10 0x20
0x1  0x2  0x4
```
你的渲染顺序是: The render logic in your tool is:
```
0 1 2
3   4
5 6 7

```
所以需要重排一下顺序. need to reorder the sequence.

另外，因为你的代码里没有build，我没法打包测试，所以我建议你提交你的打包脚本。。。
And, because there is not build script in the repo, I cannot make the test against the final code, so I suggest you push your package script so I can make a local test.

顺便，别忘记测试这个PR，JSON里的数据是按照西北到东南的顺序排列的. BTW, dont forget to test this PR, data in the json is ordered from northwest to southeast
```
[{
  id: 63288573,
  name: '闪刀姬-燎里',
  type: 67108897,
  atk: 1500,
  def: 64,
  level: 1,
  desc: '',
  race: 32,
  attribute: 4
}, 
{
  id: 1482001,
  name: '副语术士克拉拉与洛希卡',
  type: 67108897,
  atk: 0,
  def: 128,
  level: 1,
  desc: ',
  race: 2,
  attribute: 1
},
{
  id: 3507053,
  name: '干燥机块 烘干龙兽',
  type: 67108897,
  atk: 0,
  def: 256,
  level: 1,
  desc: '',
  race: 32,
  attribute: 4
},
{
  id: 30691817,
  name: '海晶少女 海天使',
  type: 67108897,
  atk: 1000,
  def: 8,
  level: 1,
  desc: '',
  race: 16777216,
  attribute: 2
},
{
  id: 13143275,
  name: '守护龙 毗斯缇',
  type: 67108897,
  atk: 1000,
  def: 32,
  level: 1,
  desc: '',
  race: 8192,
  attribute: 32
},
{
  id: 24842059,
  name: '连环栗仔球',
  type: 67108897,
  atk: 300,
  def: 1,
  level: 1,
  desc: '',
  race: 16777216,
  attribute: 32
},
{
  id: 77307161,
  name: '淘气仙星·布露姆',
  type: 67108897,
  atk: 100,
  def: 2,
  level: 1,
  desc: '',
  race: 4,
  attribute: 16
},
{
  id: 23689428,
  name: '无限起动 哥利亚巨人',
  type: 67108897,
  atk: 1000,
  def: 4,
  level: 1,
  desc: '',
  race: 32,
  attribute: 1
}]
```